### PR TITLE
Fix deprecated curly brackets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: perl
 perl:
+    - 5.22
     - 5.20
     - 5.18
     - 5.14

--- a/t/60-bind9.t
+++ b/t/60-bind9.t
@@ -58,7 +58,7 @@ my @parts = split("\n", $text);
 
 foreach my $p (@parts){
     next if $p =~ /^\/\//;
-    ok($p =~ /^zone \S+ {type master; file "/, 'testing output: ' . $p);
+    ok($p =~ /^zone \S+ \{type master; file "/, 'testing output: ' . $p);
 }
 
 done_testing();


### PR DESCRIPTION
Unescaped curly brackets in regexes are deprecated since Perl 5.22 (I think).