### PR TITLE
Fix --aggregate option #72

### DIFF
--- a/bin/cif
+++ b/bin/cif
@@ -398,7 +398,7 @@ if($ping){
         
         if($aggregate){
             $Logger->info('aggregating...');
-            $ret = $cli->aggregate({
+            $data = $cli->aggregate({
                 data        => $data,
                 aggregate   => $aggregate,
             });


### PR DESCRIPTION
$ret have been ignored during var renaming causing $cli->aggregate output to be discarded