### PR TITLE
Fix File Hash output for Bro Intel Framework feed

### DIFF
--- a/lib/CIF/SDK/Format/Bro.pm
+++ b/lib/CIF/SDK/Format/Bro.pm
@@ -17,7 +17,7 @@ use constant type_hash => {
     'url'   => 'URL',
     'fqdn'  => 'DOMAIN',
     'email' => 'EMAIL',
-    'hash'  => 'FILE_HASH',
+    'md5'  => 'FILE_HASH',
 };
     
 sub understands {


### PR DESCRIPTION
The cif command string to generate a Bro formatted Threat Intel feed for file hashes does not expect `hash` as the parameter passed to `--otype` , the proper syntax seems to be ...  `--otype md5` therefore updating the code accordingly fixes the output format of the generated Bro intel file.  Presently using the `--otype md5` generates a Bro intel feed file that is missing an entire column of data (`indicator_type`) which the Bro Intel Framework needs in order to generate informative matches in comparing malicious file hashes to observed file hashes on the network via the Bro file analysis framework.  In this particular case involving md5 hashes and when functioning properly, the missing column populates each row of data with `Intel::FILE_HASH`.  When the suggested code change is made the file generates this data column properly.  We've tested this and all appears to be functioning properly after this minor code change.