### PR TITLE
Fix zeek/bro output for ipv4/cidr to properly set Intel::SUBNET for CIDR Blocks

### DIFF
--- a/lib/CIF/SDK/Format/Bro.pm
+++ b/lib/CIF/SDK/Format/Bro.pm
@@ -14,6 +14,7 @@ use Data::Dumper;
 
 use constant type_hash => {
     'ipv4'    => 'ADDR',
+    'cidr'    => 'SUBNET',
     'url'     => 'URL',
     'fqdn'    => 'DOMAIN',
     'email'   => 'EMAIL',
@@ -41,6 +42,9 @@ sub process {
     foreach my $d (@$data){
         if($d->{'otype'} eq 'url'){
             $d->{'observable'} =~ s/^https?:\/\///g; # https://github.com/csirtgadgets/p5-cif-sdk/issues/19
+        }
+        elsif($d->{'otype'} eq 'ipv4' && $d->{'observable'} =~ '/'){
+               $d->{'otype'} = 'cidr';
         }
         my @array;
         foreach my $c (('observable','otype','tags','confidence','provider')){


### PR DESCRIPTION
Hi we are moving away from CIFv2 but in the meantime we needed to fix this (basically the same thing @sfinlon fixed very recently in python for CIFv3).  I believe this should be all set and working as expected, may be some test cases I did not account for though...